### PR TITLE
Bug Fix for resetQuiz function

### DIFF
--- a/Assets/JS/script.js
+++ b/Assets/JS/script.js
@@ -209,6 +209,9 @@ function resetQuiz() {
         <div id="answer-container">
             <!--Answers-->
         </div>
+        <div class="answer-check">
+        </div>
+
     `
 
     var elements = document.getElementsByClassName("answer-check");


### PR DESCRIPTION
This PR fixes a bug with the resetQuiz function:
- After resetting the quiz, the checkAnswer feedback "Correct!" and "Incorrect! now properly displays in it's HTML element.